### PR TITLE
fix: remove missing iOS icon reference

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,8 +13,7 @@ export const metadata: Metadata = {
       { url: "/icons/apple-icon-120x120.png", sizes: "120x120" },
       { url: "/icons/apple-icon-152x152.png", sizes: "152x152" },
       { url: "/icons/apple-icon-167x167.png", sizes: "167x167" },
-      { url: "/icons/apple-icon-180x180.png", sizes: "180x180" },
-      { url: "/icons/apple-icon-1024x1024.png", sizes: "1024x1024" }
+      { url: "/icons/apple-icon-180x180.png", sizes: "180x180" }
     ]
   }
 };


### PR DESCRIPTION
## Summary
- remove reference to non-existent 1024x1024 Apple icon

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a19c2b7f4c833084c07eabac224e4c