### PR TITLE
Update Next.js to patched 15.3.6 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "15.3.5",
+    "next": "15.3.6",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.2.22",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.7.0",
-    "eslint-config-next": "15.3.5",
+    "eslint-config-next": "15.3.6",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.5.4"


### PR DESCRIPTION
## Summary
- bump `next` and `eslint-config-next` to 15.3.6 to pick up the latest security fix
- note: package-lock was not regenerated because npm registry access returned 403 errors

## Testing
- not run (npm install blocked by registry 403; `npm run lint` prompts for initial config)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935585ce6f48330b957bf1bf0d32293)